### PR TITLE
Fix Mixed content problem on shops with SSL

### DIFF
--- a/js/seurGMap.js
+++ b/js/seurGMap.js
@@ -360,7 +360,7 @@ function saveCollectorPoint(id_cart, post_codeData )
 	
 	$.ajax({
 		url: baseDir+'modules/seur/ajax/getPickupPointsAjax.php',
-		type: 'GET',
+		type: 'POST',
 		data: {
 			savepos : true,
 			id_cart : encodeURIComponent(id_cart),
@@ -614,7 +614,7 @@ function getUserAddress(idAddress)
 	address = "";
 	$.ajax({
 		url: baseDir+'modules/seur/ajax/getPickupPointsAjax.php',
-		type: 'GET',
+		type: 'POST',
 		data: {
 			usr_id_address : encodeURIComponent(idAddress),
 			token : encodeURIComponent(current_token)
@@ -672,7 +672,7 @@ function getSeurCollectionPoints()
 	points = false;
 	$.ajax({
 		url: baseDir+'modules/seur/ajax/getPickupPointsAjax.php',
-		type: 'GET',
+		type: 'POST',
 		data: {
 			id_address_delivery : encodeURIComponent(id_address_delivery.val()),
 			token : encodeURIComponent(current_token)


### PR DESCRIPTION
When SSL is activated on all pages of the shop, ajax GET requests are being redirected.

This happpens on default FrontController.php on line 785 (Prestashop 1.6), in the method:
```
    /**
     * Redirects to correct protocol if settings and request methods don't match.
     */
    protected function sslRedirection()
    {
        // If we call a SSL controller without SSL or a non SSL controller with SSL, we redirect with the right protocol
        if (Configuration::get('PS_SSL_ENABLED') && $_SERVER['REQUEST_METHOD'] != 'POST' && $this->ssl != Tools::usingSecureMode()) {
    ...
    }
```

The condition is true and there is an HTTP redirection, what cause the mixed content problem on new browsers.

Can anyone reproduce this problem? Could be happening on other ajax GET requests.